### PR TITLE
Check device serial availability via MQTT

### DIFF
--- a/app.py
+++ b/app.py
@@ -115,6 +115,58 @@ def fetch_user_devices(user_id: int):
         devices.append(base)
     return devices
 
+# ---------- Проверка серийного номера через MQTT индекс ----------
+def lookup_claim_status(serial: str, user_id: int, con=None):
+    """Возвращает информацию о статусе устройства по серийному номеру."""
+    code = (serial or "").strip().upper()
+
+    device_id = CODE_INDEX.get(code)
+    online = False
+    owner_id = None
+
+    if device_id:
+        online = bool(ONLINE.get(device_id))
+
+        close_conn = False
+        if con is None:
+            con = db()
+            close_conn = True
+        try:
+            row = con.execute(
+                "SELECT user_id FROM devices WHERE device_id=?",
+                (device_id,)
+            ).fetchone()
+            if row:
+                owner_id = row["user_id"]
+        finally:
+            if close_conn:
+                con.close()
+
+        if owner_id is None:
+            status = "available"
+            if online:
+                message = "Устройство свободно и готово к подключению."
+            else:
+                message = "Устройство найдено, но сейчас не в сети."
+        elif owner_id == user_id:
+            status = "owned_by_you"
+            message = "Устройство уже привязано к вашему аккаунту."
+        else:
+            status = "occupied"
+            message = "Устройство уже привязано к другому аккаунту."
+    else:
+        status = "not_found"
+        message = "Устройство не в сети или уже привязано."
+
+    return {
+        "serial": code,
+        "device_id": device_id,
+        "status": status,
+        "online": online,
+        "message": message,
+        "owner_id": owner_id,
+    }
+
 # ---------- Обработчик апдейтов от MQTT (пишем состояние в БД) ----------
 def _state_to_db(device_id: str, kind: str, payload):
     with db() as con:
@@ -310,6 +362,22 @@ def api_devices_pair():
     return jsonify(ok=True, device_id=device_id, name="Сушильный шкаф")
 
 
+@app.post("/api/devices/check_serial")
+@login_required
+def api_devices_check_serial():
+    if not request.is_json:
+        return jsonify(ok=False, message="Тело должно быть JSON"), 400
+
+    data = request.get_json(silent=True) or {}
+    serial = (data.get("serial") or "").strip().upper()
+
+    if len(serial) != 6 or not serial.isalnum():
+        return jsonify(ok=False, message="Серийный номер должен состоять из 6 символов"), 400
+
+    res = lookup_claim_status(serial, g.user["id"])
+    return jsonify(ok=True, **res)
+
+
 @app.post("/api/devices/manual")
 @login_required
 def api_devices_manual_add():
@@ -330,21 +398,35 @@ def api_devices_manual_add():
     program_default = FIREPLACE_MODE_OPTIONS[0][0] if kind == "fireplace" else "standard"
 
     with db() as con:
-        row = con.execute("SELECT user_id FROM devices WHERE device_id=?", (serial,)).fetchone()
-        if row:
-            if row["user_id"] != g.user["id"]:
-                return jsonify(ok=False, message="Устройство уже привязано к другому аккаунту"), 409
-            con.execute("UPDATE devices SET kind=?, name=?, program=? WHERE device_id=?",
-                        (kind, device_name, program_default, serial))
-        else:
+        claim = lookup_claim_status(serial, g.user["id"], con=con)
+        status = claim["status"]
+
+        if status == "not_found":
+            return jsonify(ok=False, message="Устройство не найдено. Проверьте питание и подключение к сети."), 404
+        if status == "occupied":
+            return jsonify(ok=False, message="Устройство уже привязано к другому аккаунту"), 409
+        if status == "owned_by_you":
+            return jsonify(ok=False, message="Устройство уже привязано к вашему аккаунту"), 409
+        if not claim.get("online", False):
+            return jsonify(ok=False, message="Устройство найдено, но сейчас не в сети"), 409
+
+        device_id = claim.get("device_id")
+        if not device_id:
+            return jsonify(ok=False, message="Не удалось определить устройство"), 400
+
+        try:
             con.execute("""
                 INSERT INTO devices (user_id, device_id, name, kind, on_state, program, last_seen, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)
             """, (
-                g.user["id"], serial, device_name, kind, 0, program_default, None, datetime.utcnow().isoformat()
+                g.user["id"], device_id, device_name, kind, 0, program_default, None, datetime.utcnow().isoformat()
             ))
+        except sqlite3.IntegrityError:
+            # На случай гонки добавления — обновляем владельца и параметры
+            con.execute("UPDATE devices SET user_id=?, kind=?, name=?, program=? WHERE device_id=?",
+                        (g.user["id"], kind, device_name, program_default, device_id))
 
-    return jsonify(ok=True, device_id=serial, kind=kind, name=device_name)
+    return jsonify(ok=True, device_id=device_id, kind=kind, name=device_name)
 
 @app.post("/api/device/<device_id>/cmd")
 @login_required

--- a/templates/index.html
+++ b/templates/index.html
@@ -288,6 +288,7 @@
                         class="auth-input tracking-[0.3em] uppercase" required inputmode="text"
                         pattern="[A-Za-z0-9]{6}">
                 </label>
+                <div class="text-sm mt-2 hidden" data-serial-status></div>
                 <div class="text-sm mt-2 text-rose-300 hidden" data-add-error></div>
                 <div class="flex gap-3 pt-4">
                     <button type="button"
@@ -552,14 +553,32 @@
                 const serialInput = addDeviceForm?.querySelector('input[name="serial"]');
                 const kindInput = addDeviceForm?.querySelector('input[name="kind"]');
                 const nameSpan = modalAddDevice.querySelector('[data-selected-name]');
+                const statusEl = modalAddDevice.querySelector('[data-serial-status]');
                 const errorEl = modalAddDevice.querySelector('[data-add-error]');
                 const submitBtn = modalAddDevice.querySelector('[data-add-submit]');
                 const backBtn = modalAddDevice.querySelector('[data-add-back]');
                 const closeEls = modalAddDevice.querySelectorAll('[data-close-add]');
                 const kindButtons = modalAddDevice.querySelectorAll('[data-kind-btn]');
                 const addUrl = "{{ url_for('api_devices_manual_add') }}";
+                const checkSerialUrl = "{{ url_for('api_devices_check_serial') }}";
                 const deviceNames = { fireplace: "камин", dryer: "сушильный шкаф" };
                 let currentKind = null;
+                let serialCheckTimer = null;
+                let serialCheckToken = 0;
+                let lastSerialCheck = null;
+
+                function setSerialStatus(text, colorClass = "text-neutral-300") {
+                    if (!statusEl) return;
+                    statusEl.textContent = text;
+                    statusEl.className = `text-sm mt-2 ${colorClass}`;
+                    statusEl.classList.remove("hidden");
+                }
+
+                function clearSerialStatus() {
+                    if (!statusEl) return;
+                    statusEl.textContent = "";
+                    statusEl.className = "text-sm mt-2 hidden";
+                }
 
                 function showStep(step) {
                     if (!chooseStep || !serialStep) return;
@@ -588,6 +607,12 @@
                 function resetModal() {
                     currentKind = null;
                     addDeviceForm?.reset();
+                    if (serialCheckTimer) {
+                        clearTimeout(serialCheckTimer);
+                        serialCheckTimer = null;
+                    }
+                    serialCheckToken += 1;
+                    lastSerialCheck = null;
                     if (kindInput) kindInput.value = "";
                     if (serialInput) serialInput.value = "";
                     if (nameSpan) nameSpan.textContent = "";
@@ -596,6 +621,7 @@
                         submitBtn.textContent = "Подключить";
                     }
                     hideError();
+                    clearSerialStatus();
                     showStep("choose");
                 }
 
@@ -630,6 +656,9 @@
                         if (kindInput) kindInput.value = kind;
                         if (nameSpan) nameSpan.textContent = deviceNames[kind] || "";
                         hideError();
+                        clearSerialStatus();
+                        serialCheckToken += 1;
+                        lastSerialCheck = null;
                         showStep("serial");
                     });
                 });
@@ -639,6 +668,89 @@
                     if (kindInput) kindInput.value = "";
                     showStep("choose");
                     hideError();
+                    if (serialCheckTimer) {
+                        clearTimeout(serialCheckTimer);
+                        serialCheckTimer = null;
+                    }
+                    serialCheckToken += 1;
+                    lastSerialCheck = null;
+                    clearSerialStatus();
+                });
+
+                async function requestSerialStatus(serial, showPending = true) {
+                    if (!/^[A-Z0-9]{6}$/.test(serial)) {
+                        return null;
+                    }
+                    const token = ++serialCheckToken;
+                    if (showPending) {
+                        setSerialStatus("Проверяем код...", "text-neutral-300");
+                    }
+                    try {
+                        const r = await fetch(checkSerialUrl, {
+                            method: "POST",
+                            headers: { "Content-Type": "application/json" },
+                            body: JSON.stringify({ serial })
+                        });
+                        const data = await r.json().catch(() => ({}));
+                        if (token !== serialCheckToken) {
+                            return lastSerialCheck;
+                        }
+                        if (!r.ok || data.ok === false) {
+                            setSerialStatus(data.message || "Не удалось проверить код.", "text-rose-300");
+                            lastSerialCheck = null;
+                            return null;
+                        }
+
+                        const status = data.status || "not_found";
+                        const online = !!data.online;
+                        let color = "text-neutral-300";
+                        let text = data.message || "";
+                        if (status === "available") {
+                            color = online ? "text-emerald-300" : "text-amber-300";
+                            if (!text) {
+                                text = online ? "Устройство онлайн и свободно." : "Устройство найдено, но сейчас не в сети.";
+                            }
+                        } else if (status === "occupied") {
+                            color = "text-rose-300";
+                            if (!text) text = "Устройство уже привязано к другому аккаунту.";
+                        } else if (status === "owned_by_you") {
+                            color = "text-amber-300";
+                            if (!text) text = "Устройство уже привязано к вашему аккаунту.";
+                        } else {
+                            color = "text-rose-300";
+                            if (!text) text = "Устройство не в сети или уже привязано.";
+                        }
+
+                        setSerialStatus(text, color);
+                        lastSerialCheck = { serial, status, online, device_id: data.device_id };
+                        return lastSerialCheck;
+                    } catch (err) {
+                        if (token === serialCheckToken) {
+                            setSerialStatus("Не удалось проверить код. Проверьте подключение к сети.", "text-rose-300");
+                            lastSerialCheck = null;
+                        }
+                        return null;
+                    }
+                }
+
+                serialInput?.addEventListener("input", () => {
+                    if (!serialInput) return;
+                    serialInput.value = (serialInput.value || "").toUpperCase();
+                    hideError();
+                    const value = (serialInput.value || "").trim();
+                    if (serialCheckTimer) {
+                        clearTimeout(serialCheckTimer);
+                        serialCheckTimer = null;
+                    }
+                    if (/^[A-Z0-9]{6}$/.test(value)) {
+                        serialCheckTimer = setTimeout(() => {
+                            requestSerialStatus(value, true);
+                        }, 300);
+                    } else {
+                        serialCheckToken += 1;
+                        lastSerialCheck = null;
+                        clearSerialStatus();
+                    }
                 });
 
                 addDeviceForm?.addEventListener("submit", async (e) => {
@@ -656,6 +768,29 @@
                     }
 
                     hideError();
+
+                    const check = await requestSerialStatus(serial, true);
+                    if (!check) {
+                        showError("Не удалось проверить устройство. Попробуйте ещё раз.");
+                        return;
+                    }
+                    if (check.status === "not_found") {
+                        showError("Устройство не найдено. Проверьте питание и подключение к сети.");
+                        return;
+                    }
+                    if (check.status === "occupied") {
+                        showError("Устройство уже привязано к другому аккаунту.");
+                        return;
+                    }
+                    if (check.status === "owned_by_you") {
+                        showError("Устройство уже привязано к вашему аккаунту.");
+                        return;
+                    }
+                    if (!check.online) {
+                        showError("Устройство найдено, но сейчас не в сети.");
+                        return;
+                    }
+
                     submitBtn.disabled = true;
                     submitBtn.textContent = "Подключаем...";
 


### PR DESCRIPTION
## Summary
- add lookup helper and API endpoint to validate device claim codes via MQTT
- tighten manual device addition to require free online devices and reuse actual device identifiers
- extend the add-device modal to query the new API, show availability status, and block unavailable codes

## Testing
- python -m compileall app.py mqtt_bridge.py server.py

------
https://chatgpt.com/codex/tasks/task_e_68d297bb361c8323b5090c682d2eb9ce