### PR TITLE
Store device serial numbers and show them in the UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -44,6 +44,7 @@ def init_db():
             id INTEGER PRIMARY KEY AUTOINCREMENT,
             user_id INTEGER NOT NULL,
             device_id TEXT NOT NULL UNIQUE,
+            serial TEXT DEFAULT NULL,
             name TEXT NOT NULL,
             kind TEXT NOT NULL DEFAULT 'dryer',
             on_state INTEGER DEFAULT 0,
@@ -61,6 +62,8 @@ def init_db():
             con.execute("ALTER TABLE devices ADD COLUMN kind TEXT NOT NULL DEFAULT 'dryer'")
         if "state_json" not in cols:
             con.execute("ALTER TABLE devices ADD COLUMN state_json TEXT DEFAULT NULL")
+        if "serial" not in cols:
+            con.execute("ALTER TABLE devices ADD COLUMN serial TEXT DEFAULT NULL")
 init_db()
 
 # ---------- Текущий пользователь ----------
@@ -142,7 +145,7 @@ def _bool_from_payload(value, default=False):
 def fetch_user_devices(user_id: int):
     with db() as con:
         rows = con.execute("""
-            SELECT device_id, name, kind, on_state, program, state_json, last_seen, created_at
+            SELECT device_id, serial, name, kind, on_state, program, state_json, last_seen, created_at
             FROM devices WHERE user_id=? ORDER BY created_at DESC
         """, (user_id,)).fetchall()
 
@@ -165,6 +168,7 @@ def fetch_user_devices(user_id: int):
             "state": state_payload,
             "last_seen": row["last_seen"],
             "created_at": row["created_at"],
+            "serial": row["serial"],
         }
 
         if kind == "fireplace":
@@ -247,6 +251,7 @@ def _build_device_api_payload(row):
         "last_seen": row["last_seen"],
         "created_at": row["created_at"],
         "state": state_payload,
+        "serial": row["serial"],
     }
 
     if kind == "fireplace":
@@ -336,7 +341,7 @@ def _load_device_payload_for_user(con, device_id: str, user_id: int):
         return None
     row = con.execute(
         """
-        SELECT device_id, user_id, name, kind, on_state, program, state_json, last_seen, created_at
+        SELECT device_id, user_id, serial, name, kind, on_state, program, state_json, last_seen, created_at
         FROM devices WHERE device_id=?
         """,
         (device_id,),
@@ -504,7 +509,7 @@ def account_delete():
 def api_devices_list():
     with db() as con:
         rows = con.execute("""
-            SELECT device_id, name, kind, on_state, program, state_json, last_seen, created_at
+            SELECT device_id, serial, name, kind, on_state, program, state_json, last_seen, created_at
             FROM devices WHERE user_id=? ORDER BY created_at DESC
         """, (g.user["id"],)).fetchall()
     devices = [_build_device_api_payload(r) for r in rows]
@@ -546,6 +551,7 @@ def api_devices_stream():
 def api_devices_pair():
     data = request.get_json(silent=True) or {}
     code = (data.get("code") or "").strip()
+    serial = (data.get("serial") or "").strip().upper() or None
     if not code:
         return jsonify(ok=False, message="Не указан код"), 400
 
@@ -561,21 +567,28 @@ def api_devices_pair():
         exists = con.execute("SELECT 1 FROM devices WHERE device_id=?", (device_id,)).fetchone()
         if not exists:
             con.execute("""
-                INSERT INTO devices (user_id, device_id, name, kind, on_state, program, last_seen, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO devices (user_id, device_id, name, kind, serial, on_state, program, last_seen, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
                 g.user["id"],
                 device_id,
                 "Сушильный шкаф",
                 "dryer",
+                serial,
                 0,
                 "standard",
                 None,
                 datetime.utcnow().isoformat()
             ))
         else:
-            con.execute("UPDATE devices SET user_id=?, kind=?, name=?, program=? WHERE device_id=?",
-                        (g.user["id"], "dryer", "Сушильный шкаф", "standard", device_id))
+            update_fields = ["user_id=?", "kind=?", "name=?", "program=?"]
+            values = [g.user["id"], "dryer", "Сушильный шкаф", "standard"]
+            if serial:
+                update_fields.append("serial=?")
+                values.append(serial)
+            values.append(device_id)
+            sql = f"UPDATE devices SET {', '.join(update_fields)} WHERE device_id=?"
+            con.execute(sql, tuple(values))
 
     return jsonify(ok=True, device_id=device_id, name="Сушильный шкаф")
 
@@ -638,17 +651,27 @@ def api_devices_manual_add():
 
         try:
             con.execute("""
-                INSERT INTO devices (user_id, device_id, name, kind, on_state, program, last_seen, created_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO devices (user_id, device_id, name, kind, serial, on_state, program, last_seen, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, (
-                g.user["id"], device_id, device_name, kind, 0, program_default, None, datetime.utcnow().isoformat()
+                g.user["id"],
+                device_id,
+                device_name,
+                kind,
+                serial,
+                0,
+                program_default,
+                None,
+                datetime.utcnow().isoformat()
             ))
         except sqlite3.IntegrityError:
             # На случай гонки добавления — обновляем владельца и параметры
-            con.execute("UPDATE devices SET user_id=?, kind=?, name=?, program=? WHERE device_id=?",
-                        (g.user["id"], kind, device_name, program_default, device_id))
+            con.execute(
+                "UPDATE devices SET user_id=?, kind=?, name=?, program=?, serial=? WHERE device_id=?",
+                (g.user["id"], kind, device_name, program_default, serial, device_id),
+            )
 
-    return jsonify(ok=True, device_id=device_id, kind=kind, name=device_name)
+    return jsonify(ok=True, device_id=device_id, kind=kind, name=device_name, serial=serial)
 
 def _get_user_device(device_id: str):
     if not g.user:

--- a/static/device-card.js
+++ b/static/device-card.js
@@ -193,9 +193,17 @@ function updateDeviceCard(card, device) {
     indicator.classList.toggle('bg-emerald-400', online);
     indicator.classList.toggle('bg-red-500', !online);
   }
+  const rawSerial = typeof device.serial === 'string' ? device.serial.trim().toUpperCase() : '';
+  if (rawSerial) {
+    card.dataset.deviceSerial = rawSerial;
+  } else {
+    delete card.dataset.deviceSerial;
+  }
   const onlineText = card.querySelector('[data-online-text]');
   if (onlineText) {
-    onlineText.textContent = online ? 'онлайн' : 'оффлайн';
+    const statusText = online ? 'онлайн' : 'оффлайн';
+    const suffix = rawSerial ? ` · SN:${rawSerial}` : '';
+    onlineText.textContent = `${statusText}${suffix}`;
     onlineText.classList.remove('text-neutral-400', 'text-neutral-600');
     onlineText.classList.add(online ? 'text-neutral-400' : 'text-neutral-600');
   }

--- a/templates/components/device_card.html
+++ b/templates/components/device_card.html
@@ -4,9 +4,10 @@
 {% macro fireplace_card(id, title, online=True, power=False,
 mode_options=[], mode_value=None,
 sound_options=[], sound_value=None,
-backlight=False) %}
-<div class="mt-6 p-6 rounded-3xl glass border border-white/10 shadow-xl h-full flex flex-col" 
-     data-device-id="{{ id }}" data-device-kind="fireplace">
+backlight=False,
+serial=None) %}
+<div class="mt-6 p-6 rounded-3xl glass border border-white/10 shadow-xl h-full flex flex-col"
+     data-device-id="{{ id }}" data-device-kind="fireplace" data-device-serial="{{ serial or '' }}">
 
     <!-- Заголовок -->
     <div class="flex items-center justify-between">
@@ -14,7 +15,7 @@ backlight=False) %}
             <div class="h-2.5 w-2.5 rounded-full {{ 'bg-emerald-400' if online else 'bg-red-500' }}"
                 data-online-indicator></div>
             <div class="text-lg font-semibold" data-device-title>{{ title }}</div>
-            <span class="text-xs text-neutral-400" data-online-text>{{ 'онлайн' if online else 'оффлайн' }}</span>
+            <span class="text-xs text-neutral-400" data-online-text>{{ ('онлайн' if online else 'оффлайн') ~ (serial and (' · SN:' ~ serial) or '') }}</span>
         </div>
         <button type="button" class="p-2 rounded-lg hover:bg-white/10" data-open-settings>
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">
@@ -116,7 +117,8 @@ backlight=False) %}
 program_value=None,
 sound=False,
 temp_c=None,
-time_left=None) %}
+time_left=None,
+serial=None) %}
 
 {% set program_options = [
     ('1', 'Стандартный'),
@@ -127,8 +129,8 @@ time_left=None) %}
     ('6', 'Легкая глажка')
 ] %}
 
-<div class="mt-6 p-6 rounded-3xl glass border border-white/10 shadow-xl h-full flex flex-col" 
-     data-device-id="{{ id }}" data-device-kind="dryer">
+<div class="mt-6 p-6 rounded-3xl glass border border-white/10 shadow-xl h-full flex flex-col"
+     data-device-id="{{ id }}" data-device-kind="dryer" data-device-serial="{{ serial or '' }}">
 
     <!-- Заголовок -->
     <div class="flex items-center justify-between">
@@ -136,7 +138,7 @@ time_left=None) %}
             <div class="h-2.5 w-2.5 rounded-full {{ 'bg-emerald-400' if online else 'bg-red-500' }}"
                 data-online-indicator></div>
             <div class="text-lg font-semibold" data-device-title>{{ title }}</div>
-            <span class="text-xs text-neutral-400" data-online-text>{{ 'онлайн' if online else 'оффлайн' }}</span>
+            <span class="text-xs text-neutral-400" data-online-text>{{ ('онлайн' if online else 'оффлайн') ~ (serial and (' · SN:' ~ serial) or '') }}</span>
         </div>
         <button type="button" class="p-2 rounded-lg hover:bg-white/10" data-open-settings aria-label="Настройки">
             <svg width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true">

--- a/templates/index.html
+++ b/templates/index.html
@@ -220,7 +220,8 @@
                                 mode_value=device.mode_value,
                                 sound_options=device.sound_options,
                                 sound_value=device.sound_value,
-                                backlight=device.backlight
+                                backlight=device.backlight,
+                                serial=device.serial
                             ) }}
                         {% elif device.kind == 'dryer' %}
                             {{ dryer_card(
@@ -231,7 +232,8 @@
                                 program_value=device.program_value,
                                 sound=device.sound,
                                 temp_c=device.temp_c,
-                                time_left=device.time_left
+                                time_left=device.time_left,
+                                serial=device.serial
                             ) }}
                         {% endif %}
                     {% endfor %}


### PR DESCRIPTION
## Summary
- add a serial column to device records, populate it during pairing, and expose it through device payloads
- include the serial in rendered device cards so it appears beside the online/offline status
- update client-side card updates to preserve the serial in live refreshes

## Testing
- python -m compileall app.py static/device-card.js templates

------
https://chatgpt.com/codex/tasks/task_e_68d3cadfd5f083239dfd8daee34f3e4c