### PR TITLE
Display devices in addition order

### DIFF
--- a/app.py
+++ b/app.py
@@ -146,7 +146,7 @@ def fetch_user_devices(user_id: int):
     with db() as con:
         rows = con.execute("""
             SELECT device_id, serial, name, kind, on_state, program, state_json, last_seen, created_at
-            FROM devices WHERE user_id=? ORDER BY created_at DESC
+            FROM devices WHERE user_id=? ORDER BY created_at ASC
         """, (user_id,)).fetchall()
 
     devices = []
@@ -510,7 +510,7 @@ def api_devices_list():
     with db() as con:
         rows = con.execute("""
             SELECT device_id, serial, name, kind, on_state, program, state_json, last_seen, created_at
-            FROM devices WHERE user_id=? ORDER BY created_at DESC
+            FROM devices WHERE user_id=? ORDER BY created_at ASC
         """, (g.user["id"],)).fetchall()
     devices = [_build_device_api_payload(r) for r in rows]
     return jsonify(ok=True, devices=devices)


### PR DESCRIPTION
## Summary
- keep device listings ordered by creation timestamp ascending so newly added devices appear after existing ones

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d3d1580fac8323aa9368ef81747676