### PR TITLE
Expand fireplace mode options

### DIFF
--- a/app.py
+++ b/app.py
@@ -32,7 +32,9 @@ DEVICE_EVENT_LOCK = threading.Lock()
 SSE_PING_INTERVAL = 15
 
 
-FIREPLACE_MODE_OPTIONS = [(str(i), str(i)) for i in range(1, 5)]
+# Доступные режимы камина: устройства поддерживают шесть предустановок,
+# поэтому генерируем список строковых значений от 1 до 6 для отображения в UI.
+FIREPLACE_MODE_OPTIONS = [(str(i), str(i)) for i in range(1, 7)]
 FIREPLACE_SOUND_OPTIONS = [(str(i), str(i)) for i in range(1, 4)]
 
 


### PR DESCRIPTION
## Summary
- extend the fireplace mode options list to expose all six supported presets in the UI

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d4e895461c8323a86e913240701357