### PR TITLE
Sync Yandex state cache after skill commands

### DIFF
--- a/app.py
+++ b/app.py
@@ -999,6 +999,7 @@ def yandex_devices_action():
                 try:
                     bridge.publish_cmd(dev_id, {"on": desired_bool})
                     _update_device_field(dev_id, "on_state", 1 if desired_bool else 0)
+                    _update_device_state_json_fields(dev_id, {"on": desired_bool})
                     device_result["capabilities"].append({
                         "type": "devices.capabilities.on_off",
                         "state": {
@@ -1064,6 +1065,7 @@ def yandex_devices_action():
                 try:
                     bridge.publish_cmd(dev_id, {"program": desired_device_value})
                     _update_device_field(dev_id, "program", desired_device_value)
+                    _update_device_state_json_fields(dev_id, {"program": desired_device_value})
                     device_result["capabilities"].append({
                         "type": "devices.capabilities.mode",
                         "state": {


### PR DESCRIPTION
## Summary
- update the Alice command handler to persist on/off changes in the cached device JSON state
- ensure mode/program commands also refresh the stored state payload so subsequent queries report the latest value

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d4f9bbb1b48323a33fc5589e0bc632