### PR TITLE
Fix Yandex callback authorization header

### DIFF
--- a/app.py
+++ b/app.py
@@ -367,7 +367,9 @@ def _send_yandex_state_update(user_id: int, device_payload: dict, change_kind: s
 
     serialized = json.dumps(callback_payload, ensure_ascii=False)
     headers = {
-        "Authorization": f"Bearer {YANDEX_SKILL_TOKEN}",
+        # Yandex Dialogs callback API требует схемы авторизации OAuth,
+        # иначе обновление состояния игнорируется, хотя запрос принимаетcя.
+        "Authorization": f"OAuth {YANDEX_SKILL_TOKEN}",
         "Content-Type": "application/json",
     }
 


### PR DESCRIPTION
## Summary
- send Yandex callback requests with the OAuth authorization scheme instead of Bearer
- document the reason in code to avoid regressions

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d67e3fad088323a026f4bcc2b0aa7e