### PR TITLE
Fix power state parsing for Yandex status updates

### DIFF
--- a/app.py
+++ b/app.py
@@ -272,7 +272,7 @@ def _fetch_yandex_devices(user_id: int):
         if kind != "dryer":
             continue
         state_payload = _load_state_payload(row["state_json"])
-        power_state = bool(row["on_state"])
+        power_state = _bool_from_payload(row["on_state"], False)
         if "on" in state_payload:
             power_state = _bool_from_payload(state_payload.get("on"), power_state)
 
@@ -583,7 +583,7 @@ def fetch_user_devices(user_id: int):
         kind = (row["kind"] or "dryer").lower()
         state_payload = _load_state_payload(row["state_json"])
 
-        power_state = bool(row["on_state"])
+        power_state = _bool_from_payload(row["on_state"], False)
         if "on" in state_payload:
             power_state = _bool_from_payload(state_payload.get("on"), power_state)
 
@@ -665,7 +665,7 @@ def _build_device_api_payload(row):
     kind = (row["kind"] or "dryer").lower()
     state_payload = _load_state_payload(row["state_json"])
 
-    power_state = bool(row["on_state"])
+    power_state = _bool_from_payload(row["on_state"], False)
     if "on" in state_payload:
         power_state = _bool_from_payload(state_payload.get("on"), power_state)
 


### PR DESCRIPTION
## Summary
- normalize persisted on/off flags using the existing helper before exposing device state
- ensure all Yandex-related helpers work with legacy textual values in the database so callbacks reflect the correct power state

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68d67ee51d148323bfc3dac7049499f7