### PR TITLE
Improve Yandex token handling and diagnostics

### DIFF
--- a/app.py
+++ b/app.py
@@ -198,6 +198,19 @@ def _create_or_update_yandex_tokens(user_id: int, client_id: str, scope=None, re
     return access_token, new_refresh_token, access_exp
 
 
+def _issue_new_access_for_token_row(row_id: int, user_id: int, client_id: str, scope: str = None,
+                                    external_id: str = None):
+    """Выпускает новый access_token, не трогая refresh_token."""
+    access_token = _generate_token(32)
+    access_exp = (_now_utc() + timedelta(seconds=YANDEX_TOKEN_TTL)).isoformat()
+    with db() as con:
+        con.execute(
+            "UPDATE yandex_tokens SET access_token=?, expires_at=?, updated_at=? WHERE id=?",
+            (access_token, access_exp, _now_iso(), row_id),
+        )
+    return access_token, access_exp
+
+
 def _get_user_id_from_bearer(auth_header: str):
     if not auth_header or not auth_header.lower().startswith("bearer "):
         return None, None
@@ -206,17 +219,31 @@ def _get_user_id_from_bearer(auth_header: str):
         return None, None
     with db() as con:
         row = con.execute(
-            "SELECT id, user_id, expires_at, refresh_expires_at FROM yandex_tokens WHERE access_token=?",
+            "SELECT id, user_id, client_id, scope, external_account_id, expires_at, refresh_expires_at "
+            "FROM yandex_tokens WHERE access_token=?",
             (token,),
         ).fetchone()
     if not row:
         return None, None
-    expires_at = _parse_iso(row["expires_at"])
-    if not expires_at or expires_at < _now_utc():
-        return None, None
+
+    exp = _parse_iso(row["expires_at"])
     refresh_exp = _parse_iso(row["refresh_expires_at"])
+
     if refresh_exp and refresh_exp < _now_utc():
         return None, None
+
+    if exp and exp < _now_utc():
+        try:
+            _issue_new_access_for_token_row(
+                row_id=row["id"],
+                user_id=row["user_id"],
+                client_id=row["client_id"],
+                scope=row["scope"],
+                external_id=row["external_account_id"],
+            )
+        except Exception:
+            return None, None
+
     return row["user_id"], row["id"]
 
 
@@ -250,7 +277,7 @@ def _has_yandex_links_for_user(user_id: int, con=None) -> bool:
 def _validate_yandex_client(client_id: str, client_secret=None) -> bool:
     if client_id != YANDEX_CLIENT_ID:
         return False
-    if client_secret is not None and client_secret != YANDEX_CLIENT_SECRET:
+    if client_secret is not None and client_secret != "" and client_secret != YANDEX_CLIENT_SECRET:
         return False
     return True
 
@@ -950,22 +977,50 @@ def oauth_token():
     client_id = header_client_id or data.get("client_id", "")
     client_secret = header_client_secret or data.get("client_secret")
 
+    incoming_grant = (data.get("grant_type") or "").lower()
+    auth_header_value = request.headers.get("Authorization") or ""
+    headers_auth = "Basic" if auth_header_value.lower().startswith("basic ") else "none"
+    app.logger.warning(
+        "[OAUTH/TOKEN] incoming grant=%s headers_auth=%s",
+        incoming_grant or "none",
+        headers_auth,
+    )
+
     if not _validate_yandex_client(client_id, client_secret):
+        app.logger.warning(
+            "[OAUTH/TOKEN] error status=%s body=%s",
+            401,
+            {"error": "invalid_client"},
+        )
         return jsonify(error="invalid_client"), 401
 
-    grant_type = (data.get("grant_type") or "").lower()
+    grant_type = incoming_grant
     if grant_type == "authorization_code":
         code = data.get("code")
         if not code:
+            app.logger.warning(
+                "[OAUTH/TOKEN] error status=%s body=%s",
+                400,
+                {"error": "invalid_request", "error_description": "code_required"},
+            )
             return jsonify(error="invalid_request", error_description="code_required"), 400
         code_payload = _load_oauth_code(code)
         if not code_payload or code_payload.get("client_id") != client_id:
+            app.logger.warning(
+                "[OAUTH/TOKEN] error status=%s body=%s",
+                400,
+                {"error": "invalid_grant"},
+            )
             return jsonify(error="invalid_grant"), 400
         user_id = code_payload["user_id"]
         scope = code_payload.get("scope")
         external_id = code_payload.get("state")
         access_token, refresh_token, _ = _create_or_update_yandex_tokens(
             user_id, client_id, scope, external_id=external_id
+        )
+        app.logger.warning(
+            "[OAUTH/TOKEN] result 200 grant=%s",
+            grant_type,
         )
         return jsonify(
             access_token=access_token,
@@ -978,6 +1033,11 @@ def oauth_token():
     if grant_type == "refresh_token":
         refresh_token = data.get("refresh_token")
         if not refresh_token:
+            app.logger.warning(
+                "[OAUTH/TOKEN] error status=%s body=%s",
+                400,
+                {"error": "invalid_request", "error_description": "refresh_token_required"},
+            )
             return jsonify(error="invalid_request", error_description="refresh_token_required"), 400
         with db() as con:
             row = con.execute(
@@ -986,13 +1046,27 @@ def oauth_token():
                 (refresh_token, client_id),
             ).fetchone()
         if not row:
+            app.logger.warning(
+                "[OAUTH/TOKEN] error status=%s body=%s",
+                400,
+                {"error": "invalid_grant"},
+            )
             return jsonify(error="invalid_grant"), 400
         refresh_exp = _parse_iso(row["refresh_expires_at"])
         if refresh_exp and refresh_exp < _now_utc():
+            app.logger.warning(
+                "[OAUTH/TOKEN] error status=%s body=%s",
+                400,
+                {"error": "invalid_grant"},
+            )
             return jsonify(error="invalid_grant"), 400
         access_token, new_refresh_token, _ = _create_or_update_yandex_tokens(
             row["user_id"], client_id, row["scope"], refresh_token=refresh_token,
             external_id=row["external_account_id"],
+        )
+        app.logger.warning(
+            "[OAUTH/TOKEN] result 200 grant=%s",
+            grant_type,
         )
         return jsonify(
             access_token=access_token,
@@ -1002,6 +1076,11 @@ def oauth_token():
             scope=row["scope"] or "",
         )
 
+    app.logger.warning(
+        "[OAUTH/TOKEN] error status=%s body=%s",
+        400,
+        {"error": "unsupported_grant_type"},
+    )
     return jsonify(error="unsupported_grant_type"), 400
 
 


### PR DESCRIPTION
## Summary
- add automatic access token renewal when the stored token is expired but the refresh token is still valid
- allow empty client secret strings and add detailed diagnostics for /oauth/token requests

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68e38149121883239ee6f3f80fa873f2